### PR TITLE
[Common] Lint script correction

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "upgrade-deps": "yarn upgrade --latest",
     "format": "prettier --write \"src/**/*.{ts,tsx,css,scss}\"",
     "lint": "eslint --config eslint.config.ts \"{src,.storybook,linter,tests,scripts}/**/*.{ts,tsx}\"",
-    "lint:fix": "eslint \"{src,.storybook,linter,tests,scripts}/**/*.{ts,tsx}\" --fix",
+    "lint:fix": "eslint --config eslint.config.ts \"{src,.storybook,linter,tests,scripts}/**/*.{ts,tsx}\" --fix",
     "test:unit": "jest --config tests/unit/config/config.ts",
     "test:unit-cov": "jest --config tests/unit/config/config.ts --coverage",
     "test:snap": "jest --config tests/snap/config/config.ts",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only updates the `lint:fix` npm script to consistently use `eslint.config.ts`, affecting tooling but not runtime code.
> 
> **Overview**
> Aligns `lint:fix` with `lint` by adding `--config eslint.config.ts`, ensuring the autofix command uses the same flat ESLint configuration during local/dev CI runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d11037f474810b8464da0a6ef4b18b59fd1217a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->